### PR TITLE
Use DOTNET_CONTAINER_*

### DIFF
--- a/cli/azd/pkg/tools/dotnet/dotnet.go
+++ b/cli/azd/pkg/tools/dotnet/dotnet.go
@@ -167,6 +167,9 @@ func (cli *dotNetCli) PublishContainer(
 	)
 
 	runArgs = runArgs.WithEnv([]string{
+		fmt.Sprintf("DOTNET_CONTAINER_REGISTRY_UNAME=%s", username),
+		fmt.Sprintf("DOTNET_CONTAINER_REGISTRY_PWORD=%s", password),
+		// also set the legacy < .NET 9 vars
 		fmt.Sprintf("SDK_CONTAINER_REGISTRY_UNAME=%s", username),
 		fmt.Sprintf("SDK_CONTAINER_REGISTRY_PWORD=%s", password),
 	})


### PR DESCRIPTION
SDK_CONTAINER_ are now prefixed with DOTNET_CONTAINERS_ in .NET 9 (old vars work as a fallback). Set both for now until .NET 8 is out of support.